### PR TITLE
Fix slug path and dynamic import

### DIFF
--- a/app/[slug]/generateStaticParams.ts
+++ b/app/[slug]/generateStaticParams.ts
@@ -1,7 +1,7 @@
 export async function generateStaticParams() {
   return [
     { slug: "alma" },
-    { slug: "valencia-cobre29" },
+    { slug: "Cobre29" },
     // Добавляй сюда другие слаги
   ];
 }

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -9,11 +9,11 @@ type Props = {
 };
 
 // 👇 Сам компонент страницы
-export default function DemoPage({ params }: Props) {
+export default async function DemoPage({ params }: Props) {
   let data;
   try {
-    data = require(`../../data/${params.slug}.json`);
-  } catch (error) {
+    data = (await import(`../../data/${params.slug}.json`)).default;
+  } catch {
     return notFound();
   }
 
@@ -57,7 +57,7 @@ export default function DemoPage({ params }: Props) {
         <section className="mt-8">
           <h2 className="text-2xl font-semibold mb-2">Preguntas frecuentes</h2>
           <div className="space-y-4">
-            {faqs.map((faq: any, idx: number) => (
+            {faqs.map((faq: { question: string; answer: string }, idx: number) => (
               <div key={idx}>
                 <h3 className="font-medium text-lg">{faq.question}</h3>
                 <p className="text-gray-600">{faq.answer}</p>


### PR DESCRIPTION
## Summary
- ensure correct slug for Cobre 29 demo
- dynamically import JSON data and type FAQ items

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ece6ff1cc83288cc9afe2853b9cf1